### PR TITLE
Ram toolkit issue22 more custom data

### DIFF
--- a/RAM_Engine/Convert/ToBHoM.cs
+++ b/RAM_Engine/Convert/ToBHoM.cs
@@ -67,7 +67,6 @@ namespace BH.Engine.RAM
 
             // Unique RAM ID
             bhomBar.CustomData["lUID"] = IColumn.lUID;
-            bhomBar.CustomData["ElementType"] = "Column";
             bhomBar.CustomData["FrameNumber"] = IColumn.lLabel;
             bhomBar.Tags.Add("Column");
 
@@ -117,7 +116,6 @@ namespace BH.Engine.RAM
 
             // Unique RAM ID
             bhomBar.CustomData["lUID"] = IBeam.lUID;
-            bhomBar.CustomData["ElementType"] = "Beam";
             bhomBar.CustomData["FrameNumber"] = IBeam.lLabel;
             bhomBar.Tags.Add("Beam");
 
@@ -197,7 +195,6 @@ namespace BH.Engine.RAM
 
             // Unique RAM ID
             bhomBar.CustomData["lUID"] = IVerticalBrace.lUID;
-            bhomBar.CustomData["ElementType"] = "VerticalBrace";
             bhomBar.CustomData["FrameNumber"] = IVerticalBrace.lLabel;
             bhomBar.Tags.Add("VerticalBrace");
 
@@ -232,7 +229,6 @@ namespace BH.Engine.RAM
 
             // Unique RAM ID
             bhomBar.CustomData["lUID"] = IHorizBrace.lUID;
-            bhomBar.CustomData["ElementType"] = "HorizontalBrace";
             bhomBar.CustomData["FrameNumber"] = IHorizBrace.lLabel;
             bhomBar.Tags.Add("HorizontalBrace");
 


### PR DESCRIPTION
Solves #22

Added custom data to bars: label, element type, and added a BHoM tag which is the framing type, for filtering. I think it'd be a good idea to expose all the easy RAM parameters in Custom Data, especially before we've properly mapped them to BHoM properties.