### PR TITLE
RAM_Toolkit: deal with floors with no slabs present in RAM layout

### DIFF
--- a/RAM_Adapter/CRUD/Read.cs
+++ b/RAM_Adapter/CRUD/Read.cs
@@ -303,8 +303,15 @@ namespace BH.Adapter.RAM
                 for (int j = 0; j < numDecks; j++)
                 {
                     IDeck IDeck = IDecks.GetAt(j);
-                    PanelPlanar Panel = BH.Engine.RAM.Convert.ToBHoMObject(IDeck, IModel, IStoryUID);
-                    bhomPanels.Add(Panel);
+                    try
+                    {
+                        PanelPlanar Panel = BH.Engine.RAM.Convert.ToBHoMObject(IDeck, IModel, IStoryUID);
+                        bhomPanels.Add(Panel);
+                    }
+                    catch
+                    {
+                        BH.Engine.Reflection.Compute.RecordWarning("This story has no slab edges defined. IStoryUID: " + IStoryUID);
+                    }
                 }
 
             }

--- a/RAM_Adapter/RAM_Adapter.csproj
+++ b/RAM_Adapter/RAM_Adapter.csproj
@@ -45,6 +45,9 @@
     <Reference Include="Geometry_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
     </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Structure_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Structure_Engine.dll</HintPath>
       <Private>False</Private>

--- a/RAM_Engine/Convert/ToBHoM.cs
+++ b/RAM_Engine/Convert/ToBHoM.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
+using BH.oM.Architecture.Elements;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Properties;
 using BH.oM.Structure.Loads;
 using BH.Engine.Structure;
-using BH.oM.Structure.Properties;
 using RAMDATAACCESSLib;
-using BH.oM.Architecture.Elements;
 
 namespace BH.Engine.RAM
 {

--- a/RAM_Engine/RAM_Engine.csproj
+++ b/RAM_Engine/RAM_Engine.csproj
@@ -34,6 +34,10 @@
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Reflection_Engine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Structure_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Structure_Engine.dll</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
Fixes #43. Empty floors cause ToBHoM to fail to create panels. By enclosing the call to ToBHoM in a try statement, we raise a warning instead of crashing. the catch statement catches any exception, so does need to be cleaned up with only the exception we want.