### PR TITLE
Stories tweaked and check added for overlapping wall openings

### DIFF
--- a/RAM_Adapter/Convert/ToBHoM.cs
+++ b/RAM_Adapter/Convert/ToBHoM.cs
@@ -537,7 +537,7 @@ namespace BH.Adapter.RAM
             List<ICurve> wallOpeningPLs = new List<ICurve>();
             List<Opening> bhomWallOpenings = new List<Opening>();
 
-            // Create openings (disabled, causing database freeze)
+            // Create openings
             IFinalWallOpenings IFinalWallOpenings = ramWall.GetFinalOpenings();
             IRawWallOpenings rawOpenings = ramWall.GetRawOpenings();
             if (rawOpenings.GetCount() > 0)


### PR DESCRIPTION
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #150 
Closes #151 

Added a check for wall opening overlaps in ram vs opening being added to prevent crash when overlapping openings were created.
Tweaked story add behavior to fix story add bug.

### Test files
General tutorial round trip test file still applies from https://github.com/BHoM/RAM_Toolkit/pull/148. Testing pushing objects to a model already containing those objects works as it covers testing the story bug and the crash that used to occur when adding matching openings to openings in the ram model.
