### PR TITLE
Fixed member orientations and Modified Factored End Reactions behavior

### DIFF
--- a/RAM_Adapter/Create/Bar.cs
+++ b/RAM_Adapter/Create/Bar.cs
@@ -207,6 +207,7 @@ namespace BH.Adapter.RAM
                     }
 
                     //Set column properties
+                    ramColumn.dOrientation = bar.OrientationAngle;
                     IColumns colsOnStory = barStory.GetColumns();
                     IColumn column = colsOnStory.Get(ramColumn.lUID);
                     column.strSectionLabel = bar.SectionProperty.Name;

--- a/RAM_Adapter/Read/Bar.cs
+++ b/RAM_Adapter/Read/Bar.cs
@@ -91,6 +91,7 @@ namespace BH.Adapter.RAM
                 {
                     IColumn IColumn = IColumns.GetAt(j);
                     Bar bhomBar = BH.Adapter.RAM.Convert.ToBHoMObject(IColumn);
+                    bhomBar.OrientationAngle = IColumn.dOrientation;
                     RAMFrameData ramFrameData = bhomBar.FindFragment<RAMFrameData>(typeof(RAMFrameData));
                     if (ramFrameData != null)
                     {

--- a/RAM_Adapter/Read/Results.cs
+++ b/RAM_Adapter/Read/Results.cs
@@ -110,15 +110,12 @@ namespace BH.Adapter.RAM
                 try
                 {
                     gravLoads.GetMaxFactoredGravityBeamReact(beamID, ref reactLeft, ref reactRight, ref signLeft, ref signRight);
-                    //TODO: resolve below identifiers extractable through the API
-                    int mode = -1;
-                    double timeStep = 0;
 
                     RAMFactoredEndReactions bhomEndReactions = new RAMFactoredEndReactions()
                     {
                         ObjectId = beam.lUID,
-                        StartReaction = reactLeft,
-                        EndReaction = reactRight,
+                        StartReaction = reactLeft * signLeft,
+                        EndReaction = reactRight * signRight,
                     };
 
                     barEndReactions.Add(bhomEndReactions);

--- a/RAM_oM/Results/RAMFactoredEndReactions.cs
+++ b/RAM_oM/Results/RAMFactoredEndReactions.cs
@@ -39,8 +39,8 @@ namespace BH.oM.Adapters.RAM
         /***************************************************/
 
         public virtual int ObjectId { get; set; } = 0;
-        public virtual NodeReaction StartReaction { get; set; } = null;
-        public virtual NodeReaction EndReaction { get; set; } = null;
+        public virtual double StartReaction { get; set; }
+        public virtual double EndReaction { get; set; }
 
         /***************************************************/
     }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #191 
Closes #226 

Added supporting for pushing bars with orientation angle to RAM.
Modified Factored End Reactions behavior to pull factored reaction values instead of service values.

### Test files
On [Sharepoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/RAM_Toolkit/%23227-RAMSizeBug?csf=1&web=1&e=BzdHVJ)